### PR TITLE
Fixed Potential issue for same Principal during policy creation

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,10 +104,10 @@ resource "aws_opensearchserverless_access_policy" "data_policy" {
           ]
         }
       ],
-      Principal = [
+      Principal = distinct([
         data.aws_caller_identity.current.arn,
         data.aws_iam_session_context.current.issuer_arn
-      ]
+      ])
     }
   ])
 }


### PR DESCRIPTION
I was using this module to run with the Bedrock agent module but was getting the following error have resolved it by using distinct function 

Policy json is invalid, error:
│ [$[0].Principal: the items in the array must be unique]